### PR TITLE
General fixes for CURIEs, prefixes, and transform errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ The dump will be in the form of n-triples, with individual sets of records in ne
 Run BioPortal-to-KGX with all validation and metadata retrieval options as:
 
 ```
-python run.py --input ../path/to/your/data/ --kgx_validate --robot_validate --pandas_validate --get_bioportal_metadata --ncbo_key YOUR_NCBO_API_KEY_HERE
+python run.py --input ../path/to/your/data/ --kgx_validate --robot_validate --pandas_validate --write_curies --remap_types --get_bioportal_metadata --ncbo_key YOUR_NCBO_API_KEY_HERE 
 ```
 
-Specify individual ontologies to include or exclude with the --include_only and --exclude options, respectively, each followed by a comma-delimited list of the original hashed file ID from the 4store dump. 
+Specify individual ontologies to include or exclude with the --include_only and --exclude options, respectively, each followed by a comma-delimited list of the original hashed file ID from the 4store dump.
 
 For example:
 ```
@@ -29,3 +29,7 @@ python run.py --input ../path/to/your/data/ --include_only dabd4d902360003975fb2
 Output will be written to the `/bioportal_to_kgx` directory within `/transformed`, with subdirectories named for the 4store graph and each subgraph.
 
 Each subgraph will contain node and edge files ({subgraph_name}_nodes.tsv and {subgraph_name}_edges.tsv, respectively) along with logs containing any validation messages about the transforms.
+
+## Troubleshooting
+
+* The `--robot_validate` option may fail on larger ontologies like `NCBITAXON` with `java.lang.OutOfMemoryError`. Consider omitting this option or running ROBOT on files directly, as needed.

--- a/bioportal_to_kgx/functions.py
+++ b/bioportal_to_kgx/functions.py
@@ -308,6 +308,7 @@ def do_transforms(paths: list,
                             input_format='obojson',
                             output=outpath,
                             output_format='tsv',
+                            stream=True,
                             knowledge_sources=[("aggregator_knowledge_source", "BioPortal"),
                                                 ("primary_knowledge_source", primary_knowledge_source)])
                     txs_complete[outname] = True

--- a/bioportal_to_kgx/functions.py
+++ b/bioportal_to_kgx/functions.py
@@ -729,7 +729,8 @@ def remove_bad_curie(filepath: str) -> str:
     with open(filepath, 'r') as infile:
         with open(repaired_filepath, 'w') as outfile:
             for line in infile:
-                line = re.sub("file:C:", "", line)
+                for pattern in ["file:C:","file:"]:
+                    line = re.sub(pattern, "", line)
                 outfile.write(line)
 
     return repaired_filepath

--- a/bioportal_to_kgx/functions.py
+++ b/bioportal_to_kgx/functions.py
@@ -324,6 +324,7 @@ def do_transforms(paths: list,
                             input_format='obojson',
                             output=outpath,
                             output_format='tsv',
+                            stream=True,
                             knowledge_sources=[("aggregator_knowledge_source", "BioPortal"),
                                                 ("primary_knowledge_source", primary_knowledge_source)])
                         txs_complete[outname] = True

--- a/prefixes/bioportal-preferred-prefixes.tsv
+++ b/prefixes/bioportal-preferred-prefixes.tsv
@@ -1,3 +1,4 @@
 ontology	preferred_prefix
 RO	BIOPORTAL.RO
 OBOREL	RO
+EO	BIOPORTAL.EO


### PR DESCRIPTION
* Add preferred prefix EO->BIOPORTAL.EO, as EO may otherwise refer to the (deprecated) Plant Environment Ontology
* Update README
* Have KGX transform use streaming - not a massive speedup here but preferable by defauly
* Repair instances of `file:` being mistaken for CURIE, not just `file:C:` - `GAZ` is the offender here