### PR TITLE
Refactor prefix normalization

### DIFF
--- a/bioportal_to_kgx/functions.py
+++ b/bioportal_to_kgx/functions.py
@@ -24,8 +24,6 @@ NAMESPACE = "data.bioontology.org"
 TARGET_TYPE = "ontologies"
 PREFIX_DIR = "prefixes"
 PREFIX_FILENAME = "bioportal-prefixes-curated.tsv"
-PREF_PREFIX_FILENAME = "bioportal-preferred-prefixes.tsv"
-
 
 def examine_data_directory(input: str, include_only: list, exclude: list):
     """

--- a/bioportal_to_kgx/functions.py
+++ b/bioportal_to_kgx/functions.py
@@ -11,17 +11,24 @@ import kgx.cli  # type: ignore
 import pandas as pd  # type: ignore
 from universalizer.norm import clean_and_normalize_graph
 
-from bioportal_to_kgx.bioportal_utils import (bioportal_metadata,
-                                              check_header_for_md,
-                                              manually_add_md)
-from bioportal_to_kgx.robot_utils import (initialize_robot, relax_ontology,
-                                          robot_measure, robot_remove,
-                                          robot_report)
+from bioportal_to_kgx.bioportal_utils import (
+    bioportal_metadata,
+    check_header_for_md,
+    manually_add_md,
+)
+from bioportal_to_kgx.robot_utils import (
+    initialize_robot,
+    relax_ontology,
+    robot_measure,
+    robot_remove,
+    robot_report,
+)
 from bioportal_to_kgx.stats import make_transform_stats
 
 TXDIR = "transformed"
 NAMESPACE = "data.bioontology.org"
 TARGET_TYPE = "ontologies"
+
 
 def examine_data_directory(input: str, include_only: list, exclude: list):
     """
@@ -211,7 +218,6 @@ def do_transforms(
                 continue
 
             if ok_to_transform:
-
                 print(f"ROBOT: relax {outname}")
                 relaxed_outpath = os.path.join(outdir, outname + "_relaxed.json")
                 if relax_ontology(robot_path, tempname, relaxed_outpath, robot_env):

--- a/bioportal_to_kgx/functions.py
+++ b/bioportal_to_kgx/functions.py
@@ -11,18 +11,12 @@ import kgx.cli  # type: ignore
 import pandas as pd  # type: ignore
 from universalizer.norm import clean_and_normalize_graph
 
-from bioportal_to_kgx.bioportal_utils import (
-    bioportal_metadata,
-    check_header_for_md,
-    manually_add_md,
-)
-from bioportal_to_kgx.robot_utils import (
-    initialize_robot,
-    relax_ontology,
-    robot_measure,
-    robot_remove,
-    robot_report,
-)
+from bioportal_to_kgx.bioportal_utils import (bioportal_metadata,
+                                              check_header_for_md,
+                                              manually_add_md)
+from bioportal_to_kgx.robot_utils import (initialize_robot, relax_ontology,
+                                          robot_measure, robot_remove,
+                                          robot_report)
 from bioportal_to_kgx.stats import make_transform_stats
 
 TXDIR = "transformed"

--- a/bioportal_to_kgx/functions.py
+++ b/bioportal_to_kgx/functions.py
@@ -22,8 +22,6 @@ from bioportal_to_kgx.stats import make_transform_stats
 TXDIR = "transformed"
 NAMESPACE = "data.bioontology.org"
 TARGET_TYPE = "ontologies"
-PREFIX_DIR = "prefixes"
-PREFIX_FILENAME = "bioportal-prefixes-curated.tsv"
 
 def examine_data_directory(input: str, include_only: list, exclude: list):
     """

--- a/prefixes/bioportal-preferred-prefixes.tsv
+++ b/prefixes/bioportal-preferred-prefixes.tsv
@@ -1,4 +1,0 @@
-ontology	preferred_prefix
-RO	BIOPORTAL.RO
-OBOREL	RO
-EO	BIOPORTAL.EO

--- a/prefixes/bioportal-prefixes-readme.md
+++ b/prefixes/bioportal-prefixes-readme.md
@@ -4,7 +4,7 @@ Prefixes used across IRIs within BioPortal ontologies are identified within `bio
 
 This file contains the following columns:
 
-* ontology - The name of the ontology using the prefix
+* ontology - The name of the ontology using the prefix, within BioPortal
 * prefix  - The string of the prefix (e.g., 'http://childhealthservicemodels.eu/asthma')
 * delimiter - The delimiter separating the prefix from the class ID (e.g, '#')
 * native - True if the prefix refers to classes of the ontology itself, False if it is from a imported/referenced ontology, or otherwise Unknown.
@@ -14,5 +14,3 @@ Not all ontologies have a native prefix - some are entirely imports.
 
 Manually-curated prefixes are primarily native, rather than the set of all prefixes used within each ontology.
 Some non-native prefixes are included.
-
-The file `bioportal-preferred-prefixes` contains mappings from Bioportal ontology names to preferred names. These are used in order to avoid conflicts across ontology sources, e.g., `RO` in OBO Foundry is the Relation Ontology, while in BioPortal `RO` refers to the Radiomics Ontology. To avoid conflict, CURIEs for nodes from the latter are prefixed with BIOPORTAL.RO. The BioPortal name for the Relation Ontology, `OBOREL`, is prefixed as `RO` for greater cross-platform interoperability.


### PR DESCRIPTION
More of the prefix normalization can be handled by prefixmaps + Bioregistry.
This is already mostly handled by `universalizer`, so this PR is primarily about removing unused material.